### PR TITLE
Add balanced fill tracking to avoid unecessary re-randomization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+configs/
 trader/configs/
 trader/scripts/
 terminator/configs/

--- a/plugins/balancedLevelProvider.go
+++ b/plugins/balancedLevelProvider.go
@@ -113,7 +113,7 @@ func (p *balancedLevelProvider) GetLevels(maxAssetBase float64, maxAssetQuote fl
 
 	levels, e := p.recomputeLevels(maxAssetBase, maxAssetQuote)
 	if e != nil {
-		fmt.Errorf("unable to generate new levels: %s", e)
+		return nil, fmt.Errorf("unable to generate new levels: %s", e)
 	}
 
 	p.lastLevels = levels


### PR DESCRIPTION
This implements a fill tracker for the balanced strategy that simply toggles a boolean for whether to regen levels. If no fills happen the existing levels will be re-submitted.

Addresses https://github.com/interstellar/kelp/issues/52