### PR TITLE
add CCXT's FetchOHLCV call

### DIFF
--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -647,3 +647,31 @@ func TestCancelOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchOHLCV(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	c, e := MakeInitializedCcxtExchange("http://localhost:3000", "binance", api.ExchangeAPIKey{})
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
+		return
+	}
+
+	m, e := c.FetchOHLCV("BTC/USDT", "1h")
+	if e != nil {
+		assert.Fail(t, fmt.Sprintf("error when fetching tickers: %s", e))
+		return
+	}
+
+	assert.IsType(t, []CcxtCandle{}, m)
+	for i := range m {
+		assert.True(t, m[i].TimeStamp > 0)
+		assert.True(t, m[i].Open > 0.0)
+		assert.True(t, m[i].High > 0.0)
+		assert.True(t, m[i].Low > 0.0)
+		assert.True(t, m[i].Close > 0.0)
+		assert.True(t, m[i].Volume > 0.0)
+	}
+}


### PR DESCRIPTION
I'm thinking about indicator-based strategies, and CCXT has a fetchOHLCV call for candlestick data that wasn't in our _support/sdk/cctx.go_. This supports the historical data feature https://github.com/interstellar/kelp/issues/10.

Of our supported CCXT exchanges, it works for Binance and Bittrex; Poloniex doesn't recognize this CCXT call.